### PR TITLE
Update Observatory Home.json to use relative dashboard links instead …

### DIFF
--- a/grafana/grafana_provisioning/dashboards/PANOSETI/Observatory Home.json
+++ b/grafana/grafana_provisioning/dashboards/PANOSETI/Observatory Home.json
@@ -170,7 +170,7 @@
                 "value": [
                   {
                     "title": "More details",
-                    "url": "http://128.114.176.40:3000/d/oVK2NBrnk/examine-specific-quabo?${__url_time_range}&var-quabo=${__series.name}&var-observatory=${observatory}"
+                    "url": "/d/oVK2NBrnk/examine-specific-quabo?${__url_time_range}&var-quabo=${__series.name}&var-observatory=${observatory}"
                   }
                 ]
               }
@@ -570,7 +570,7 @@
       "links": [
         {
           "title": "GPS Home",
-          "url": "http://128.114.176.40:3000/d/uGFNmE9nk/gps-home?from=${__from}&to=${__to}&var-quabo=${__series.name}&var-observatory=${observatory}"
+          "url": "/d/uGFNmE9nk/gps-home?from=${__from}&to=${__to}&var-quabo=${__series.name}&var-observatory=${observatory}"
         }
       ],
       "maxDataPoints": 100,


### PR DESCRIPTION
…of hardcoded links

Follows the advice from this [Stack Overflow thread](https://stackoverflow.com/questions/61612381/how-do-you-make-links-in-grafana-table-panel-from-a-cell-relative-so-they-can-s)

Closes panoseti/panoseti/issues/190

I tested this change on the headnode grafana and it works.